### PR TITLE
Token refresh, open-in-browser crash fixes.

### DIFF
--- a/Morpho/composeApp/src/desktopMain/kotlin/com/morpho/app/util/LinkParsing.desktop.kt
+++ b/Morpho/composeApp/src/desktopMain/kotlin/com/morpho/app/util/LinkParsing.desktop.kt
@@ -2,8 +2,25 @@ package com.morpho.app.util
 
 import java.awt.Desktop
 import java.net.URI
+import java.util.Locale
+
 
 actual fun openBrowser(url: String) {
+    val osName by lazy(LazyThreadSafetyMode.NONE) { System.getProperty("os.name").lowercase(Locale.ROOT) }
     val desktop = Desktop.getDesktop()
-    desktop.browse(URI.create(url))
+    try {
+        when {
+            Desktop.isDesktopSupported() && desktop.isSupported(Desktop.Action.BROWSE) -> {
+                desktop.browse(URI.create(url))
+            }
+            "mac" in osName -> {
+                Runtime.getRuntime().exec("open $url")
+            }
+            "nix" in osName || "nux" in osName -> Runtime.getRuntime().exec("xdg-open $url")
+            else -> throw RuntimeException("cannot open $url")
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
 }
+

--- a/Morpho/composeApp/src/desktopMain/kotlin/main.kt
+++ b/Morpho/composeApp/src/desktopMain/kotlin/main.kt
@@ -27,6 +27,7 @@ import com.morpho.app.di.appModule
 import com.morpho.app.di.dataModule
 import com.morpho.app.di.storageModule
 import com.morpho.app.ui.theme.MorphoTheme
+import com.morpho.butterfly.Butterfly
 import com.morpho.butterfly.auth.SessionRepository
 import com.morpho.butterfly.auth.UserRepository
 import kotlinx.coroutines.flow.firstOrNull
@@ -68,7 +69,8 @@ fun main() = application {
     koin.get<SessionRepository> { parametersOf(storageDir) }
     koin.get<UserRepository> { parametersOf(storageDir) }
     val prefs = koin.get<PreferencesRepository> { parametersOf(storageDir) }
-    //koin.get<Butterfly>()
+    val api = koin.get<Butterfly>()
+
     val morphoPrefs = runBlocking {
         prefs.prefs.firstOrNull()?.firstOrNull()?.morphoPrefs
     }
@@ -85,7 +87,12 @@ fun main() = application {
     )
 
     Window(
-        onCloseRequest = ::exitApplication,
+        onCloseRequest = {
+            runBlocking {
+                api.refreshSession()
+            }
+            (::exitApplication)()
+        },
         state = windowState,
         title = "Morpho",
         undecorated = undecorated,
@@ -96,7 +103,12 @@ fun main() = application {
             if(undecorated) {
                 MorphoWindow(
                     windowState = windowState,
-                    onCloseRequest = ::exitApplication
+                    onCloseRequest = {
+                        runBlocking {
+                            api.refreshSession()
+                        }
+                        (::exitApplication)()
+                    }
                 ) {
                     App()
                 }

--- a/Morpho/composeApp/src/desktopMain/kotlin/main.kt
+++ b/Morpho/composeApp/src/desktopMain/kotlin/main.kt
@@ -89,7 +89,7 @@ fun main() = application {
     Window(
         onCloseRequest = {
             runBlocking {
-                api.refreshSession()
+                api.refreshSession().join()
             }
             (::exitApplication)()
         },
@@ -105,7 +105,7 @@ fun main() = application {
                     windowState = windowState,
                     onCloseRequest = {
                         runBlocking {
-                            api.refreshSession()
+                            api.refreshSession().join()
                         }
                         (::exitApplication)()
                     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Morpho
 Fast, flexible native multi-platform client for Bluesky (and possibly other ATProto applications).
 
-Currently supporting Android and non-Apple desktop platforms. ~~Will support Apple once I can get my partner to update his MacBook Pro.~~
+Currently supporting Android and non-Apple desktop platforms. Will support MacOS and iOS ~~once I can get my partner to update his MacBook Pro~~ once Nova gets her dev environment set up.
 
 ### Goals:  
  - Fast


### PR DESCRIPTION
Think I fixed the token refresh problems finally.

Fixed the crash on opening a web link on Linux (execs "xdg-open" or the MacOS equivalent instead of making the built-in API call, which seems to be Windows-only).

Also some work in the post composer, and fixing a follow-on bug to the new thread logic.